### PR TITLE
Add documentation about Leaflet and VectorGrid

### DIFF
--- a/docs/website/leaflet.md
+++ b/docs/website/leaflet.md
@@ -1,0 +1,99 @@
+---
+layout: docs
+category: website
+title: Leaflet
+description: Leaflet
+keywords: Leaflet VectorGrid
+---
+
+[Leaflet](http://www.leafletjs.org) is a lightweight web mapping library. It doesn't
+support vector tiles by default, but the [VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid)
+plugin allows to load them.
+
+If you haven't worked with Leaflet before, have a look at its [tutorials](http://leafletjs.com/examples.html).
+
+<iframe src="/maps/leaflet-vectorgrid.html" frameborder="0" scrolling="0" width="100%" height="540px" style="margin-bottom:25px;"></iframe>
+
+### Load Leaflet and VectorGrid
+
+Put this in the `<head>` of your HTML page:
+
+```html
+<head>
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>
+</head>
+```
+
+Also notice which versions of Leaflet and VectorGrid you are loading, as there
+might be newer releases.
+
+### Define a style
+
+VectorGrid cannot (yet) handle vector tile styles, so first you'll have to define the
+styling for all the data layers:
+
+```js
+var vectorStyles = {
+	water: {	// Apply these options to the "water" layer...
+		fill: true,
+		weight: 1,
+		fillColor: '#06cccc',
+		color: '#06cccc',
+		fillOpacity: 0.2,
+		opacity: 0.4,
+	},
+	transportation: {	// Apply these options to the "transportation" layer...
+		weight: 0.5,
+		color: '#f2b648',
+		fillOpacity: 0.2,
+		opacity: 0.4,
+	},
+
+	// And so on, until every layer in https://openmaptiles.org/schema/ has a style
+
+	// aeroway:
+	// boundary:
+	// building:
+	// housenumber:
+	// landcover:
+	// landuse:
+	// park:
+	// place:
+	// poi:
+	// transportation:
+	// transportation_name:
+	// water:
+	// water_name:
+	// waterway:
+};
+```
+
+If you have worked with Leaflet before, you'll notice that those options are the same
+that are used for `L.Polyline`s and `L.Polygon`s.
+
+That is a very basic styling for the data. Consult [VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid)'s
+documentation for how to apply more complex styles.
+
+### Create your VectorGrid
+
+Once you have your style, create an instance of `L.VectorGrid.Protobuf` like this:
+
+```js
+var openMapTilesUrl = "https://free-{s}.tilehosting.com/data/v3/{z}/{x}/{y}.pbf.pict?key={key}"
+
+var openMapTilesLayer = L.vectorGrid.protobuf(openMapTilesUrl, {
+	vectorTileLayerStyles: vectorStyles,
+	subdomains: '0123',
+	attribution: '© OpenStreetMap contributors, © OpenMapTiles',
+	key: 'abcdefghi01234567890' // Get yours at https://openmaptiles.com/hosting/
+});
+```
+
+And add your layer to your Leaflet map:
+
+```js
+openMapTilesLayer.addTo(map);
+```
+

--- a/maps/leaflet-vectorgrid.html
+++ b/maps/leaflet-vectorgrid.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>OpenMapTiles in Leaflet + VectorGrid</title>
+	<meta charset="utf-8" />
+
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+	<link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
+	<script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
+	<script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>
+</head>
+<body style='margin:0'>
+	<div id="map" style="width: 100vw; height: 100vh; background: white"></div>
+
+	<script>
+
+		var map = L.map('map');
+
+		var vectorTileStyling = {
+
+			water: {
+				fill: true,
+				weight: 1,
+				fillColor: '#06cccc',
+				color: '#06cccc',
+				fillOpacity: 0.2,
+				opacity: 0.4,
+			},
+			admin: {
+				weight: 1,
+				fillColor: 'pink',
+				color: 'pink',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			waterway: {
+				weight: 1,
+				fillColor: '#2375e0',
+				color: '#2375e0',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			landcover: {
+				fill: true,
+				weight: 1,
+				fillColor: '#53e033',
+				color: '#53e033',
+				fillOpacity: 0.2,
+				opacity: 0.4,
+			},
+			landuse: {
+				fill: true,
+				weight: 1,
+				fillColor: '#e5b404',
+				color: '#e5b404',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			park: {
+				fill: true,
+				weight: 1,
+				fillColor: '#84ea5b',
+				color: '#84ea5b',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			boundary: {
+				weight: 1,
+				fillColor: '#c545d3',
+				color: '#c545d3',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			aeroway: {
+				weight: 1,
+				fillColor: '#51aeb5',
+				color: '#51aeb5',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			transportation: {	// openmaptiles only
+				weight: 0.5,
+				fillColor: '#f2b648',
+				color: '#f2b648',
+				fillOpacity: 0.2,
+				opacity: 0.4,
+// 					dashArray: [4, 4]
+			},
+			building: {
+				fill: true,
+				weight: 1,
+				fillColor: '#2b2b2b',
+				color: '#2b2b2b',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			water_name: {
+				weight: 1,
+				fillColor: '#022c5b',
+				color: '#022c5b',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			transportation_name: {
+				weight: 1,
+				fillColor: '#bc6b38',
+				color: '#bc6b38',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			place: {
+				weight: 1,
+				fillColor: '#f20e93',
+				color: '#f20e93',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			housenumber: {
+				weight: 1,
+				fillColor: '#ef4c8b',
+				color: '#ef4c8b',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+			poi: {
+				weight: 1,
+				fillColor: '#3bb50a',
+				color: '#3bb50a',
+				fillOpacity: 0.2,
+				opacity: 0.4
+			},
+
+			// Do not symbolize some stuff for openmaptiles
+			country_name: [],
+			marine_name: [],
+			state_name: [],
+			place_name: [],
+			waterway_name: [],
+			poi_name: [],
+			road_name: [],
+			housenum_name: [],
+		};
+
+		var openmaptilesUrl = "https://free-{s}.tilehosting.com/data/v3/{z}/{x}/{y}.pbf.pict?key={key}";
+
+		var openmaptilesVectorTileOptions = {
+			rendererFactory: L.canvas.tile,
+			attribution: '<a href="https://openmaptiles.org/">&copy; OpenMapTiles</a>, <a href="http://www.openstreetmap.org/copyright">&copy; OpenStreetMap</a> contributors',
+			vectorTileLayerStyles: vectorTileStyling,
+			subdomains: '0123',
+			key: 'UmmATPUongHdDmIicgs7',
+			maxZoom: 14
+		};
+
+		var openmaptilesPbfLayer = L.vectorGrid.protobuf(openmaptilesUrl, openmaptilesVectorTileOptions).addTo(map);
+
+		map.fitWorld();
+
+	</script>
+</body>
+</html>


### PR DESCRIPTION
Adds a working `Leaflet.VectorGrid` example to the website.

I cannot run Jekyll locally (it chokes on an error about `File to import not found or unreadable: _reset`, and the readme doesn't say if I need extra gems or anything), so I haven't double-checked if this looks nice after Jekyll builds the website.