### PR TITLE
Fix broken link in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@ redirect_from:
 
           <h3 class="padt-2">3. Follow the step-by-step guide</h3>
           <p>
-            Visit the web interface at <b>http://localhost:8080/</b> or click in the Preview window and follow the web wizard. You will set your server in few steps. Supports adding your own data and styles. There are more data sources such as hillshading, contour lines, satellite, etc. See more at <a href="openmaptiles.com/server/">openmaptiles.com/server/</a>
+            Visit the web interface at <b>http://localhost:8080/</b> or click in the Preview window and follow the web wizard. You will set your server in few steps. Supports adding your own data and styles. There are more data sources such as hillshading, contour lines, satellite, etc. See more at <a href="https://openmaptiles.com/server/">openmaptiles.com/server/</a>
           </p>
         </div>
 


### PR DESCRIPTION
Fixing a link that currently redirects to `https://openmaptiles.org/docs/openmaptiles.com/server/` without the protocol specified.