### PR TITLE
Update repository and description

### DIFF
--- a/styles.html
+++ b/styles.html
@@ -176,13 +176,13 @@ keywords: Open styles, map templates, catography, Mapbox GL, map gallery
       <div class="style-title clearfix">
         <h2>
           <span>OSM Liberty</span>
-          <a class="github-button" href="https://github.com/lukasmartinelli/osm-liberty" data-icon="octicon-star" data-style="mega" data-count-href="/lukasmartinelli/osm-liberty/stargazers" data-count-api="/repos/lukasmartinelli/osm-liberty#stargazers_count">Star</a>
+          <a class="github-button" href="https://github.com/maputnik/osm-liberty" data-icon="octicon-star" data-style="mega" data-count-href="/maputnik/osm-liberty/stargazers" data-count-api="/repos/maputnik/osm-liberty#stargazers_count">Star</a>
         </h2>
-        <a class="btn style-btn" href="http://editor.openmaptiles.org?style=https://rawgit.com/lukasmartinelli/osm-liberty/gh-pages/style.json">Edit in Maputnik</a>
-        <a class="btn style-btn style-github-btn" href="https://github.com/lukasmartinelli/osm-liberty">View on GitHub</a>
+        <a class="btn style-btn" href="http://editor.openmaptiles.org?style=https://rawgit.com/maputnik/osm-liberty/gh-pages/style.json">Edit in Maputnik</a>
+        <a class="btn style-btn style-github-btn" href="https://github.com/maputnik/osm-liberty">View on GitHub</a>
       </div>
       <p>
-        A free Mapbox GL basemap from OpenStreetMap with complete liberty to use and self host. OSM Liberty is a fork of OSM Bright based on free data sources with a mission for a clear good looking design for the everyday user.
+        A free Mapbox GL basemap style for everyone with complete liberty to use and self host. OSM Liberty is a fork of OSM Bright based on free data sources with a mission for a clear good looking design for the everyday user.
       </p>
       <div class="map-style" id="osm-liberty"></div>
    </div>


### PR DESCRIPTION
The OSM Liberty repository has been transferred from `lukasmartinelli` to `maputnik`:

https://github.com/maputnik/osm-liberty