### PR TITLE
Fix styles page

### DIFF
--- a/_data/styles.json
+++ b/_data/styles.json
@@ -1,53 +1,62 @@
 [
   {
-    "title": "Klokantech basic",
+    "title": "Klokantech Basic",
     "description": "Klokantech Basic is basemap which tries to stay in the background and only give the most relevant information.",
     "url-github": "https://github.com/openmaptiles/klokantech-basic-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#basic//vector/1/0/0",
-    "img": "basic.jpg"
+    "img": "basic.jpg",
+    "id": "klokantech-basic"
   },{
     "title": "OSM Bright",
     "description": "OSM Bright is a general purpose base map showcasing the great detail of OpenStreetMap data. It is a good starting point for your own complex base maps.",
     "url-github": "https://github.com/openmaptiles/osm-bright-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#bright//vector/1/0/0",
-    "img": "bright.jpg"
+    "img": "bright.jpg",
+    "id": "osm-bright"
   },{
     "title": "Positron",
     "description": "Positron is beautiful light base map which is ideal for a non obtrusive basemap for your data visualizations. The cartography by Stamen Design is licensed under CC0.",
     "url-github": "https://github.com/openmaptiles/positron-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#positron//vector/1/0/0",
-    "img": "positron.jpg"
+    "img": "positron.jpg",
+    "id": "positron"
   },{
     "title": "Dark Matter",
     "description": "Dark Matter is a dark base map and a good starting point for other darker designs. The cartography by Stamen Design is licensed under CC0.",
     "url-github": "https://github.com/openmaptiles/dark-matter-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#darkmatter//vector/1/0/0",
-    "img": "darkmatter.jpg"
+    "img": "darkmatter.jpg",
+    "id": "dark-matter"
   },{
     "title": "Klokantech 3D",
     "description": "A Map showcasing 3D buildings.",
     "url-github": "https://github.com/openmaptiles/klokantech-3d-gl-style",
-    "img": "3d.jpg"
+    "img": "3d.jpg",
+    "id": "klokantech-3d"
   },{
     "title": "Klokantech Terrain",
     "description": "A basic map style showing the contour lines and hillshading from OpenMapTiles.com.",
     "url-github": "https://github.com/openmaptiles/klokantech-terrain-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#topo//vector/1/0/0",
-    "img": "terrain.jpg"
+    "img": "terrain.jpg",
+    "id": "klokantech-terrain"
   },{
     "title": "Fiord Color",
     "description": "A blue basemap for visualizations.",
     "url-github": "https://github.com/openmaptiles/fiord-color-gl-style",
-    "img": "fiord.jpg"
+    "img": "fiord.jpg",
+    "id": "fiord-color"
   },{
     "title": "Toner",
     "description": "Port of the Stamen Maps Toner style.",
     "url-github": "https://github.com/openmaptiles/toner-gl-style",
-    "img": "toner.jpg"
+    "img": "toner.jpg",
+    "id": "toner"
   },{
     "title": "OSM Liberty",
     "description": "A free Mapbox GL basemap style for everyone with complete liberty to use and self host. OSM Liberty is a fork of OSM Bright based on free data sources with a mission for a clear good looking design for the everyday user.",
     "url-github": "https://github.com/maputnik/osm-liberty",
-    "img": "liberty.jpg"
+    "img": "liberty.jpg",
+    "id": "osm-liberty"
   },
 ]

--- a/styles.html
+++ b/styles.html
@@ -50,10 +50,10 @@ keywords: Open styles, map templates, cartography, Mapbox GL, map gallery
 
   <div class="row">
     <div class="col3 pady-2 padx-0">
+      <h4><a href="#klokantech-basic">Klokantech Basic</a></h4>
+      <h4><a href="#osm-bright">OSM Bright</a></h4>
       <h4><a href="#positron">Positron</a></h4>
       <h4><a href="#dark-matter">Dark Matter</a></h4>
-      <h4><a href="#osm-bright">OSM Bright</a></h4>
-      <h4><a href="#klokantech-basic">Klokantech Basic</a></h4>
       <h4><a href="#klokantech-3d">Klokantech 3D</a></h4>
       <h4><a href="#klokantech-terrain">Klokantech Terrain</a></h4>
       <h4><a href="#fiord-color">Fiord Color</a></h4>
@@ -64,7 +64,7 @@ keywords: Open styles, map templates, cartography, Mapbox GL, map gallery
 
       {% for style in site.data.styles %}
       <div class="style-title clearfix">
-        <h2>
+        <h2 id="{{ style.id }}">
           <span>{{ style.title }}</span>
         </h2>
         {% if style.url-cloud %}


### PR DESCRIPTION
After the changes in https://github.com/openmaptiles/www.openmaptiles.org/commit/e41c4e95d4c1f524281de5c2ab792bed3bce6f0d (thanks @daliborjanak!) the links for the GL styles on the left side are not working anymore.

Also the order of the styles in that list is different compared to the order on the page.

This PR fixes this.

![auswahl_516](https://user-images.githubusercontent.com/20856381/50289782-119c2100-046a-11e9-9574-bb4a8830a9ef.png) 