### PR TITLE
Highway exit documentation update

### DIFF
--- a/layers/transportation_name.md
+++ b/layers/transportation_name.md
@@ -6,16 +6,15 @@ etl_graph: media/etl_transportation_name.png
 mapping_graph: media/mapping_transportation_name.png
 sql_query: SELECT geometry, name, name_en, name_de, NULLIF(tags->'name_int', '') AS "name_int", NULLIF(tags->'name:latin', '') AS "name:latin", NULLIF(tags->'name:nonlatin', '') AS "name:nonlatin", ref, ref_length, network::text, class::text, subclass, brunnel, layer, level, indoor FROM layer_transportation_name(ST_SetSRID('BOX3D(-20037508.34 -20037508.34, 20037508.34 20037508.34)'::box3d, 3857 ), 14)
 ---
-This is the layer for labelling the highways. Only highways that are named `name=*` and are long enough
-to place text upon appear. The OSM roads are stitched together if they contain the same name
-to have better label placement than having many small linestrings.
-For motorways you should use the `ref` field to label them while for other roads you should use `name`.
+This is the layer for labelling features associated with highways.  This includes:
+- Highway labels, which can be used to display text labels or highway shields along a road.  Only highways that are named `name=*` and are long enough to place text upon appear. The OSM roads are stitched together if they contain the same name to have better label placement than having many small linestrings.  For motorways you should use the `ref` field to label them while for other roads you should use `name`.
+- Highway exits (`highway=motorway_junction`)
 
 ## Fields
 
 ### name
 
-The OSM [`name`](http://wiki.openstreetmap.org/wiki/Highways#Names_and_references) value of the highway.
+The OSM [`name`](http://wiki.openstreetmap.org/wiki/Highways#Names_and_references) value of the highway or exit.
 
 ### name_en
 
@@ -83,9 +82,10 @@ Possible values:
 
 ### subclass
 
-Distinguish more specific classes of path:
+Distinguish more specific classes of `highway=*`.
 Subclass is value of the
-[`highway`](http://wiki.openstreetmap.org/wiki/Key:highway) (for paths).
+[`highway`](http://wiki.openstreetmap.org/wiki/Key:highway) (for paths), or `junction` for
+[`motorway_junction`](http://wiki.openstreetmap.org/wiki/Tag:highway=motorway_junction).
 
 Possible values:
 
@@ -97,7 +97,7 @@ Possible values:
 - `bridleway`
 - `corridor`
 - `platform`
-
+- `junction`
 
 ### brunnel
 

--- a/layers/transportation_name.md
+++ b/layers/transportation_name.md
@@ -52,7 +52,7 @@ Possible values:
 
 ### class
 
-Distinguish between more and less important roads and roads under construction.
+Distinguish between more and less important roads and roads under construction.  For a `motorway_junction`, the class will be the highest class of road that the junction intersects.
 
 Possible values:
 


### PR DESCRIPTION
This PR is a documentation update for openmaptiles/openmaptiles#1119, which adds support for highway exits (via the OSM tag `highway=motorway_junction`)

For highway junctions, the `class` will be the highest highway classification that intersects the junction (so if a junction joins a motorway and trunk, the class would be `motorway`).

`subclass` will be always `junction` for highway exits.