### PR TITLE
Update display maps examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site
 .sass-cache
 .jekyll-cache
+.jekyll-metadata
+_config.local.yaml

--- a/_data/categories.json
+++ b/_data/categories.json
@@ -7,7 +7,7 @@
   {
     "id": "website",
     "title": "Display Map",
-    "desc": "Display vector tiles in a web client using either MapLibre GL, Leaflet, Tangram or OpenLayers."
+    "desc": "Display vector tiles in a web client using either MapTiler SDK JS, MapLibre GL, Leaflet, Tangram or OpenLayers."
   },
   {
     "id": "host",

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -34,7 +34,11 @@ layout: default
       <ul>
         {% assign articles = site.pages | where:"category", category.id | sort: "order" %}
         {% for article in articles %}
-        <li><a href="{{ article.url }}">{% if article.titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% if article.redirect %}
+          <li><a href="{{ article.redirect }}">{% if article.titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% else %}
+          <li><a href="{{ article.url }}">{% if article.titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% endif %}
         {% endfor %}
       </ul>
     </div>

--- a/docs/website/leaflet.md
+++ b/docs/website/leaflet.md
@@ -3,147 +3,17 @@ layout: docs
 category: website
 title: Leaflet
 description: Display maps on a web using the Leaflet JavaScript library.
-order: 4
+order: 3
+redirect: https://docs.maptiler.com/leaflet/vector-tiles-in-leaflet-js/
 ---
 
-[Leaflet](http://www.leafletjs.com) is a lightweight open-source library for online maps. If you haven't worked with Leaflet before, take a look at its [tutorials](http://leafletjs.com/examples.html).
-
-There are three ways how to use OpenMapTiles as a map layer in Leaflet:
-* raster tiles from server
-* vector tiles with [mapbox-gl-leaflet](https://github.com/mapbox/mapbox-gl-leaflet) plugin
-* vector tiles with [VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid) plugin
-
-### Raster tiles from server
-
-Leaflet doesn't support vector tiles by default. For basemaps, it is recommended to use it with traditional raster tiles (Mercator XYZ). Such tiles can be generated on demand for any of the [GL styles](/styles/) with the open-source server software called [TileServer GL](/docs/host/tileserver-gl/).
-
-A preview of the Leaflet viewer showing the raster tiles is available at [viewers](https://openmaptiles.org/viewers/) example page.
-
-
-### Vector tiles with a mapbox-gl-leaflet plugin
-
-Leaflet can also load and render the vector tiles directly - with the help of the [mapbox-gl-leaflet](https://github.com/mapbox/mapbox-gl-leaflet) plugin.
-
-The plugin is experimental and it is not actively supported by Mapbox.
-
-<iframe src="/maps/leaflet-mapbox-gl.html" frameborder="0" scrolling="0" width="100%" height="540px" style="margin-bottom:25px;"></iframe>
-
-
-#### Load Leaflet and mapbox-gl-leaflet
-
-Paste this code in the `<head>` section of your HTML page:
-
-```html
-<head>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
-  <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.css" rel='stylesheet' />
-  <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v0.35.1/mapbox-gl.js"></script>
-  <script src="/js/leaflet-mapbox-gl.js"></script>
-</head>
-```
-
-Always check which versions of Leaflet, mapbox-gl and mapbox-gl-js you are using, because there might be a newer version.
-
-#### Create your VectorGrid
-
-Create an instance of `L.mapboxGL` like this:
-
-```js
-var map = L.map('map');
-map.options.minZoom = 2;
-var gl = L.mapboxGL({
-    accessToken: '{token}',
-    style: 'https://openmaptiles.github.io/osm-bright-gl-style/style-cdn.json'
-}).addTo(map);
-map.fitWorld();
-```
-
-Notice the `style` property that points to a [GL style](/styles/) that you have chosen for the map. The style contains path to OpanMapTiles data as well as its visualization. If you are not using data from Mapbox hosting, the `accessToken` property can be set to any string.
-
-### Vector tiles with a VectorGrid plugin
-
-Leaflet has also the ability to load and render the vector tiles directly - with the help of the [VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid) plugin.
-
-The plugin is not yet ready for drawing the basemaps with fonts etc but is very practical for other applications.
-
-<iframe src="/maps/leaflet-vectorgrid.html" frameborder="0" scrolling="0" width="100%" height="540px" style="margin-bottom:25px;"></iframe>
-
-#### Load Leaflet and VectorGrid
-
-Paste this code in the `<head>` section of your HTML page:
-
-```html
-<head>
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.3/dist/leaflet.css" />
-  <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"></script>
-  <script src="https://unpkg.com/leaflet.vectorgrid@1.2.0"></script>
-</head>
-```
-
-Always check which versions of Leaflet and VectorGrid you are using, because there might be a newer version.
-
-#### Define a style
-
-VectorGrid cannot handle vector tile GL styles (yet), therefore first you have to define the styling for all the data layers with the [Leaflet specific styling code](http://leafletjs.com/reference-1.0.3.html#path):
-
-```js
-var vectorStyles = {
-  water: {	// Apply these options to the "water" layer...
-    fill: true,
-    weight: 1,
-    fillColor: '#06cccc',
-    color: '#06cccc',
-    fillOpacity: 0.2,
-    opacity: 0.4,
-  },
-  transportation: {	// Apply these options to the "transportation" layer...
-    weight: 0.5,
-    color: '#f2b648',
-    fillOpacity: 0.2,
-    opacity: 0.4,
-  },
-
-  // And so on, until every layer in https://openmaptiles.org/schema/ has a style
-
-  // aeroway:
-  // boundary:
-  // building:
-  // housenumber:
-  // landcover:
-  // landuse:
-  // park:
-  // place:
-  // poi:
-  // transportation:
-  // transportation_name:
-  // water:
-  // water_name:
-  // waterway:
-};
-```
-
-If you have worked with Leaflet before, you'll notice that those options are the same as the ones used for `L.Polyline`s and `L.Polygon`s.
-
-That is a very basic styling for the data. Check [VectorGrid](https://github.com/Leaflet/Leaflet.VectorGrid)'s documentation for more info about how to apply more complex styles.
-
-#### Create your VectorGrid
-
-Once your style is ready, create an instance of `L.VectorGrid.Protobuf` like this:
-
-```js
-var openmaptilesUrl = "https://api.maptiler.com/tiles/v3-openmaptiles/{z}/{x}/{y}.pbf?key={key}";
-
-var openMapTilesLayer = L.vectorGrid.protobuf(openMapTilesUrl, {
-  vectorTileLayerStyles: vectorStyles,
-  subdomains: '0123',
-  attribution: '© OpenStreetMap contributors, © MapTiler',
-  key: 'abcdefghi01234567890' // Get yours at https://maptiler.com/cloud/
-});
-```
-
-And add your layer to your Leaflet map:
-
-```js
-openMapTilesLayer.addTo(map);
-```
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://docs.maptiler.com/leaflet/vector-tiles-in-leaflet-js/">
+  <meta http-equiv="refresh" content="0; url=https://docs.maptiler.com/leaflet/vector-tiles-in-leaflet-js/">
+  <h1>Redirecting…</h1>
+  <a href="https://docs.maptiler.com/leaflet/vector-tiles-in-leaflet-js/">Click here if you are not redirected.</a>
+  <script>location = "https://docs.maptiler.com/leaflet/vector-tiles-in-leaflet-js/"</script>
+</html>

--- a/docs/website/maplibre-gl-js.md
+++ b/docs/website/maplibre-gl-js.md
@@ -3,7 +3,7 @@ layout: docs
 category: website
 title: MapLibre GL JS
 description: Display maps on a web using the modern MapLibre GL JavaScript library.
-order: 1
+order: 2
 redirect_from: /docs/website/mapbox-gl-js/
 ---
 
@@ -15,7 +15,7 @@ Using MapLibre GL JS for serving OpenMapTiles tileset is the most common use cas
 
 ### Reference the Style
 
-Create an HTML page and include the MapLibre GL JS viewer. You need to point the `style` to an HTTP endpoint of your [Mapbox GL style specification JSON](/docs/style/mapbox-gl-style-spec).
+Create an HTML page and include the MapLibre GL JS viewer. You need to point the `style` to an HTTP endpoint of your [GL style specification JSON](/docs/style/mapbox-gl-style-spec).
 
 ```html
 <!DOCTYPE html>
@@ -24,8 +24,8 @@ Create an HTML page and include the MapLibre GL JS viewer. You need to point the
     <meta charset='utf-8' />
     <title>OpenMapTiles OSM Bright style</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src="https://unpkg.com/maplibre-gl@1.14.0-rc.1/dist/maplibre-gl.js"></script>
-    <link href="https://unpkg.com/maplibre-gl@1.14.0-rc.1/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
         body { margin:0; padding:0; }
         #map { position:absolute; top:0; bottom:0; width:100%; }
@@ -36,7 +36,7 @@ Create an HTML page and include the MapLibre GL JS viewer. You need to point the
     <script>
         var map = new maplibregl.Map({
             container: 'map',
-            style: '{{ site.maps.domain }}/maps/bright/style.json?key=<key>',
+            style: '{{ site.maps.domain }}/maps/bright/style.json?key=insert_your_key_here',
             center: [8.5456, 47.3739],
             zoom: 11
         });
@@ -60,4 +60,4 @@ All [OpenMapTiles styles](/styles/) can be referenced directly in a viewer.
 
 ### Fonts and Sprites
 
-MapLibre GL JS requires fonts being packaged as PBFs and symbols packaged as sprites. Check the [Mapbox GL style specification documentation](/docs/style/mapbox-gl-style-spec) for OpenMapTiles to create your own fonts and sprites packages.
+MapLibre GL JS requires fonts being packaged as PBFs and symbols packaged as sprites. Check the [GL style specification documentation](/docs/style/mapbox-gl-style-spec) for OpenMapTiles to create your own fonts and sprites packages.

--- a/docs/website/maptiler-sdk-js.md
+++ b/docs/website/maptiler-sdk-js.md
@@ -1,0 +1,19 @@
+---
+layout: docs
+category: website
+title: MapTiler SDK JS
+description: Display maps on a web using the modern MapTiler SDK JS library.
+order: 1
+redirect: https://docs.maptiler.com/sdk-js/
+---
+
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link rel="canonical" href="https://docs.maptiler.com/sdk-js/">
+  <meta http-equiv="refresh" content="0; url=https://docs.maptiler.com/sdk-js/">
+  <h1>Redirecting…</h1>
+  <a href="https://docs.maptiler.com/sdk-js/">Click here if you are not redirected.</a>
+  <script>location = "https://docs.maptiler.com/sdk-js/"</script>
+</html>

--- a/docs/website/openlayers.md
+++ b/docs/website/openlayers.md
@@ -3,7 +3,7 @@ layout: docs
 category: website
 title: OpenLayers
 description: Display maps on a web using the OpenLayers JavaScript library.
-order: 2
+order: 4
 ---
 
 There are two ways how to display OpenMapTiles with [OpenLayers](http://openlayers.org/) library: using raster or vector tiles.
@@ -33,7 +33,7 @@ Create an HTML page and include OpenLayers with the standalone build of [ol-mapb
 <head>
   <title>Klokantech Basic GL Style using ol-mapbox-style preview</title>
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v5.3.0/css/ol.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v7.2.2/ol.css">
   <style>
     html, body {
       height: 100%;
@@ -48,10 +48,10 @@ Create an HTML page and include OpenLayers with the standalone build of [ol-mapb
 </head>
 <body>
   <div id="map"></div>
-  <script>var apiKey = '{{ site.maps.key }}'</script>
+  <script>var apiKey = 'insert_your_key_here'</script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,Promise"></script>
-  <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v5.3.0/build/ol.js"></script>
-  <script src="https://unpkg.com/ol-mapbox-style@3.6.2/dist/olms.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js"></script>
+  <script src="https://unpkg.com/ol-mapbox-style@9.4.0/dist/olms.js"></script>
   <script src="ol.js"></script>
 </body>
 ```
@@ -63,10 +63,7 @@ The code below uses [ol-mapbox-style](https://npmjs.com/package/ol-mapbox-style)
 In the following code, you have to replace “insert_your_key_here” with a key from hosting. You can get a free key at [www.maptiler.com/cloud/](https://www.maptiler.com/cloud/).
 
 ```javascript
-var apiKey = 'insert_your_key_here';
-
-olms('map', '{{ site.maps.domain }}/maps/basic/style.json?key=' + apiKey).then(function(map) {
+olms.apply('map', '{{ site.maps.domain }}/maps/basic/style.json?key=' + apiKey).then(function(map) {
   // do anything with the passed `ol.Map` instance here.
 });
-
 ```

--- a/maps/maplibre-gl-js.html
+++ b/maps/maplibre-gl-js.html
@@ -8,8 +8,8 @@ permalink: /maps/maplibre-gl-js.html
     <meta charset='utf-8' />
     <title>OpenMapTiles OSM Bright style</title>
     <meta name='viewport' content='initial-scale=1,maximum-scale=1,user-scalable=no' />
-    <script src="https://unpkg.com/maplibre-gl@1.14.0-rc.1/dist/maplibre-gl.js"></script>
-    <link href="https://unpkg.com/maplibre-gl@1.14.0-rc.1/dist/maplibre-gl.css" rel="stylesheet" />
+    <script src="https://unpkg.com/maplibre-gl/dist/maplibre-gl.js"></script>
+    <link href="https://unpkg.com/maplibre-gl/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
         body { margin:0; padding:0; }
         #map { position:absolute; top:0; bottom:0; width:100%; }

--- a/maps/ol.html
+++ b/maps/ol.html
@@ -7,7 +7,7 @@ permalink: /maps/ol.html
 <head>
   <title>Klokantech Basic GL Style using ol-mapbox-style preview</title>
   <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Open+Sans" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v5.3.0/css/ol.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v7.2.2/ol.css">
   <style>
     html, body {
       height: 100%;
@@ -24,7 +24,7 @@ permalink: /maps/ol.html
   <div id="map"></div>
   <script>var apiKey = '{{ site.maps.key }}'</script>
   <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=fetch,Promise"></script>
-  <script src="https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@master/en/v5.3.0/build/ol.js"></script>
-  <script src="https://unpkg.com/ol-mapbox-style@3.6.2/dist/olms.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/ol@v7.2.2/dist/ol.js"></script>
+  <script src="https://unpkg.com/ol-mapbox-style@9.4.0/dist/olms.js"></script>
   <script src="ol.js"></script>
 </body>

--- a/maps/ol.js
+++ b/maps/ol.js
@@ -1,1 +1,1 @@
-olms('map', 'https://api.maptiler.com/maps/basic/style.json?key=' + apiKey);
+olms.apply('map', 'https://api.maptiler.com/maps/basic/style.json?key=' + apiKey);


### PR DESCRIPTION
* Update OpenLayers example. Update OL version and olms version
* Update MapLibre example. Update MapLibre GL to latest version
* Redirect Leaflet example. Now the example use L.maptilerLayer plugin instead the experimental mapbox-gl-leaflet
* Add MapTiler SDK JS example.