### PR TITLE
Add article redirect option to docs main page tutorials menu

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -154,14 +154,17 @@ redirect_from:
     </div>
   </div>
 
-
   <div class="col4">
     <h2 class="padb-1">Tutorials</h2> {% for category in site.data.categories %}
     <div class="row doc-section">
       <h4>{{ category.title }}</h4>
       <ul>
         {% assign articles = site.pages | where:"category", category.id | sort: "order" %} {% for article in articles %}
-        <li><a href="{{ article.url }}">{% if titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% if article.redirect %}
+          <li><a href="{{ article.redirect }}">{% if article.titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% else %}
+          <li><a href="{{ article.url }}">{% if article.titlesidebar %}{{ article.titlesidebar }}{% else %}{{ article.title }}{% endif %}</a></li>
+        {% endif %}
         {% endfor %}
       </ul>
     </div>


### PR DESCRIPTION
This allows to put external links in the menus on the right bar.

Fix use the article titlesidebar