### PR TITLE
Fix port number of `maptiler/tileserver-gl`

### DIFF
--- a/docs/host/tileserver-gl.md
+++ b/docs/host/tileserver-gl.md
@@ -28,10 +28,10 @@ curl -o zurich_switzerland.mbtiles https://[ADDRESS-YOU-GET-IN-DOWNLOADS]
 
 ## Serve Map Tiles
 
-You should mount the current directory containing the vector tiles to the `/data` path inside of the container and bind the local port `8080` to port `80` inside of the container:
+You should mount the current directory containing the vector tiles to the `/data` path inside of the container and bind the local port `8080` to port `8080` inside of the container:
 
 ```bash
-docker run -it -v $(pwd):/data -p 8080:80 maptiler/tileserver-gl
+docker run -it -v $(pwd):/data -p 8080:8080 maptiler/tileserver-gl
 ```
 
 or from OpenMapTiles repository

--- a/docs/raster/tileserver-gl.md
+++ b/docs/raster/tileserver-gl.md
@@ -28,10 +28,10 @@ curl -o zurich_switzerland.mbtiles https://[ADDRESS-YOU-GET-IN-DOWNLOADS]
 
 ## Serve Map Tiles
 
-You should mount the current directory containing the vector tiles to the `/data` path inside of the container and bind the local port `8080` to port `80` inside of the container:
+You should mount the current directory containing the vector tiles to the `/data` path inside of the container and bind the local port `8080` to port `8080` inside of the container:
 
 ```bash
-docker run -it -v $(pwd):/data -p 8080:80 maptiler/tileserver-gl
+docker run -it -v $(pwd):/data -p 8080:8080 maptiler/tileserver-gl
 ```
 
 or from the OpenMapTiles repository


### PR DESCRIPTION
The `maptiler/tileserver-gl` container now runs on port 8080 instead of 80. Updated documentation.

References: 
https://github.com/maptiler/tileserver-gl/pull/638
https://github.com/maptiler/tileserver-gl/commit/c134795b8113b4bb676e0237ce4a681d6097f67a
https://stackoverflow.com/questions/74545652/tileserver-gl-issue-with-port-8080
