### PR TITLE
Add missing prerequisite for make command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -49,6 +49,10 @@ is open source and licensed under <a href="https://github.com/openmaptiles/openm
 
         <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>docker-compose pull</code></pre></div></div>
 
+        <p>Install the Make tool.</p>
+
+        <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>apt install build-essential</code></pre></div></div>
+        
         <p>Now generate the vector tiles using the quickstart bash script.</p>
 
         <div class="language-bash highlighter-rouge"><div class="highlight"><pre class="highlight"><code>./quickstart.sh</code></pre></div></div>


### PR DESCRIPTION
The quickstart.sh script requires the 'make' command, which is not installed by default on Ubuntu installations. This commit adds the necessary installation step for the build-essential package to the documentation.

- Added instruction to install build-essential package
- This resolves the "make: command not found" error during quickstart.sh execution
- Improves user experience by preventing a common setup error

Related error:
./quickstart.sh: line 114: make: command not found
