### PR TITLE
Correct attribution for Stamen styles

### DIFF
--- a/_data/styles.json
+++ b/_data/styles.json
@@ -22,14 +22,14 @@
     "id": "osm-bright"
   },{
     "title": "Positron",
-    "description": "Positron is beautiful light base map which is ideal for a non obtrusive basemap for your data visualizations. The cartography by Stamen Design is licensed under CC0.",
+    "description": "Positron is beautiful light base map which is ideal for a non obtrusive basemap for your data visualizations. The cartography by Stamen Design is licensed under CC-BY.",
     "url-github": "https://github.com/openmaptiles/positron-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#positron//vector/1/0/0",
     "img": "positron.jpg",
     "id": "positron"
   },{
     "title": "Dark Matter",
-    "description": "Dark Matter is a dark base map and a good starting point for other darker designs. The cartography by Stamen Design is licensed under CC0.",
+    "description": "Dark Matter is a dark base map and a good starting point for other darker designs. The cartography by Stamen Design is licensed under CC-BY.",
     "url-github": "https://github.com/openmaptiles/dark-matter-gl-style",
     "url-cloud":"https://www.maptiler.com/maps/#darkmatter//vector/1/0/0",
     "img": "darkmatter.jpg",


### PR DESCRIPTION
The attribution for the original Stamen-designed CARTO basemap styles Positron and Dark Matter are CC-BY 3.0 (see here: https://github.com/CartoDB/CartoDB-basemaps/blob/master/LICENSE.txt)

The OpenMapTiles.org website incorrectly lists these as [CC0](https://creativecommons.org/public-domain/cc0/) (Public Domain) which is not the same thing.