### PR TITLE
Don't link to closed-source versions of OSM Bright and MapTiler Basic

### DIFF
--- a/_data/styles.json
+++ b/_data/styles.json
@@ -10,14 +10,14 @@
     "title": "MapTiler Basic",
     "description": "MapTiler Basic is basemap which tries to stay in the background and only give the most relevant information.",
     "url-github": "https://github.com/openmaptiles/maptiler-basic-gl-style",
-    "url-cloud":"basic-v2",
+    "url-cloud":"basic",
     "img": "basic.jpg",
     "id": "maptiler-basic"
   },{
     "title": "OSM Bright",
     "description": "OSM Bright is a general purpose base map showcasing the great detail of OpenStreetMap data. It is a good starting point for your own complex base maps.",
     "url-github": "https://github.com/openmaptiles/osm-bright-gl-style",
-    "url-cloud":"bright-v2",
+    "url-cloud":"bright",
     "img": "bright.jpg",
     "id": "osm-bright"
   },{


### PR DESCRIPTION
v2 of MapTiler Basic and OSM Bright carry the notice

> You are licensed to use the style or its derivate for serving map tiles exclusively with MapTiler Server or MapTiler Cloud and in accordance with their licenses and terms. If you plan to use the style in a different way, contact us at sales@maptiler.com.

This is not an open source license. Additionally, the v2 style diverges from the linked open-source repository.

See also https://github.com/openmaptiles/maptiler-basic-gl-style/issues/26