### PR TITLE
Update link for mobile app development documentation

### DIFF
--- a/mobile.html
+++ b/mobile.html
@@ -28,7 +28,7 @@ description: 0nline & offline OpenStreetMap vector tiles created by OpenMapTiles
 
     <p>The maps are powered by the MapLibre library, which loads maps from MapTiler Cloud. Look&feel of the map is derived from the <a href="/styles/#osm-bright">OSM Bright style</a>. It can be adjusted to display features, information, and colors according to the intended use case.</p>
 
-    <p class="center pady-2"><a class="btn" href="https://docs.maptiler.com/flutter/">Develop your own mobile app</a></p>
+    <p class="center pady-2"><a class="btn" href="https://docs.maptiler.com/guides/maps-apis/maps-platform/how-to-build-mobile-apps-with-maps-using-sdk/">Develop your own mobile app</a></p>
   </div>
 
   <div class="col4">


### PR DESCRIPTION
Previously, the link pointed to the Flutter example. This new link leads to a page explaining all the options (Native, PWA, etc.).